### PR TITLE
ci: pass VERBOSE to the test harness

### DIFF
--- a/.github/workflows/unit_tests.sh
+++ b/.github/workflows/unit_tests.sh
@@ -101,14 +101,11 @@ for phase in "${PHASES[@]}"; do
             autoreconf -i -f
             ./configure --enable-maintainer-mode
             make -j$(nproc) V=1
-            if ! make V=1 check; then
-                cat tests/test-suite.log
-                exit 1
-            fi
+            make V=1 VERBOSE=1 check
 
             # elfutils fails to compile with clang and --enable-sanitize-undefined
             if [[ "$phase" != "RUN_CLANG" ]]; then
-                make V=1 distcheck
+                make V=1 VERBOSE=1 distcheck
             fi
             ;;
         RUN_GCC_ASAN_UBSAN|RUN_CLANG_ASAN_UBSAN)
@@ -169,10 +166,7 @@ for phase in "${PHASES[@]}"; do
                 ASAN_OPTIONS="$ASAN_OPTIONS:detect_leaks=0" make -j$(nproc) V=1
             fi
 
-            if ! make V=1 check; then
-                cat tests/test-suite.log
-                exit 1
-            fi
+            make V=1 VERBOSE=1 check
             ;;
         COVERITY)
             coverity_install_script

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,7 +40,7 @@ jobs:
           autoreconf -i -f
           ./configure --enable-maintainer-mode --enable-gcov
           make -j$(nproc) V=1
-          make V=1 check
+          make V=1 VERBOSE=1 check
           make V=1 coverage
       - name: Coveralls
         uses: coverallsapp/github-action@9ba913c152ae4be1327bfb9085dc806cedb44057


### PR DESCRIPTION
https://www.gnu.org/software/automake/manual/html_node/Parallel-Test-Harness.html

The output from failed tests is collected in the test-suite.log file.
If the variable ‘VERBOSE’ is set, this file is output after the summary.